### PR TITLE
v.3.5 fix missing form_type

### DIFF
--- a/agent/structures.go
+++ b/agent/structures.go
@@ -380,6 +380,7 @@ type eventSpecific struct {
 	Text              json.RawMessage `json:"text"`
 	TextVars          json.RawMessage `json:"text_vars"`
 	Fields            json.RawMessage `json:"fields"`
+	FormType          json.RawMessage `json:"form_type"`
 	ContentType       json.RawMessage `json:"content_type"`
 	Name              json.RawMessage `json:"name"`
 	URL               json.RawMessage `json:"url"`
@@ -417,6 +418,7 @@ type FilledForm struct {
 		Type  string `json:"type"`
 		Value string `json:"value"`
 	} `json:"fields"`
+	FormType string `json:"form_type"`
 	Event
 }
 
@@ -430,6 +432,9 @@ func (e *Event) FilledForm() *FilledForm {
 
 	f.Event = *e
 	if err := json.Unmarshal(e.Fields, &f.Fields); err != nil {
+		return nil
+	}
+	if err := json.Unmarshal(e.FormType, &f.FormType); err != nil {
 		return nil
 	}
 	return &f

--- a/customer/structures.go
+++ b/customer/structures.go
@@ -303,6 +303,7 @@ type eventSpecific struct {
 	Text              json.RawMessage `json:"text"`
 	TextVars          json.RawMessage `json:"text_vars"`
 	Fields            json.RawMessage `json:"fields"`
+	FormType          json.RawMessage `json:"form_type"`
 	ContentType       json.RawMessage `json:"content_type"`
 	Name              json.RawMessage `json:"name"`
 	URL               json.RawMessage `json:"url"`
@@ -340,6 +341,7 @@ type FilledForm struct {
 		Type  string `json:"type"`
 		Value string `json:"value"`
 	} `json:"fields"`
+	FormType string `json:"form_type"`
 	Event
 }
 
@@ -353,6 +355,9 @@ func (e *Event) FilledForm() *FilledForm {
 
 	f.Event = *e
 	if err := json.Unmarshal(e.Fields, &f.Fields); err != nil {
+		return nil
+	}
+	if err := json.Unmarshal(e.FormType, &f.FormType); err != nil {
 		return nil
 	}
 	return &f


### PR DESCRIPTION
`form_type` is missing in structs, making SDK unable to detect whether a filled form is a pre-chat or a post-chat form.