### PR TITLE
API-13513: fix examples/echo v3.4

### DIFF
--- a/examples/echo/README.md
+++ b/examples/echo/README.md
@@ -22,7 +22,6 @@
 	4. Add `webhooks--all:rw` and `chats--all:rw` to the list of requested scopes.
 	5. Use `$NGROK_PUBLIC_URL/oauth` as the Direct installation URL in the Marketplace authorization flow settings section.
 
-**Attention!** For production applications, you can skip point 4.5.
 Having troubles? Visit docs dedicated page for [creating LiveChat apps](https://developers.livechatinc.com/docs/getting-started/guides/#creating-livechat-apps).
 
 ## Running this example

--- a/examples/echo/installation-handler.go
+++ b/examples/echo/installation-handler.go
@@ -53,6 +53,7 @@ func (h *InstallationHandler) Handle(w http.ResponseWriter, r *http.Request) {
 		URL:         h.cfg.WebhookURL,
 		Description: "echo integration",
 		Filters:     &configuration.WebhookFilters{AuthorType: "customer"},
+		Type:        "license",
 	}
 
 	whID, err := api.RegisterWebhook(wh, nil)


### PR DESCRIPTION
- assigned required `type` parameter while calling register_webhook
- removed missleading readme mention