### PR TITLE
chore: pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -12,10 +12,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@bfdd3570ce990073878bf10f6b2d79082de49492 # v2.2.0
         with:
           go-version: ${{ env.GO_VERSION }}
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
       - name: Run Unit Tests
         run: go test -v ./...


### PR DESCRIPTION
## SHA Pinning — automated PR

This PR pins all GitHub Actions workflow steps to immutable commit SHAs.

### What changed

All mutable GitHub Actions tag references (e.g. `@v3`) have been replaced with immutable commit SHA pins plus a version comment, for example:

```yaml
# before
- uses: actions/checkout@v4
# after
- uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
```

Dependabot will keep the SHA pins up-to-date – it's natively [supported by GitHub](https://github.blog/changelog/2025-08-15-github-actions-policy-now-supports-blocking-and-sha-pinning-actions/).

### Why

A mutable tag can be silently re-pointed to a malicious commit. SHA pins guarantee exactly which code runs in CI.  
See: [tj-actions/changed-files incident (March 2025)](https://www.stepsecurity.io/blog/harden-runner-detection-tj-actions-changed-files-action-is-compromised)

### Review checklist

- [ ] Spot-check a few SHA pins against the upstream action repo
- [ ] Verify CI still passes after merge
- [ ] **Merge into `v3.7`**
