### PR TITLE
fixup: add omitempty to userSpecific struct

### DIFF
--- a/agent/structures.go
+++ b/agent/structures.go
@@ -76,25 +76,25 @@ type User struct {
 }
 
 type userSpecific struct {
-	PhoneNumber                json.RawMessage `json:"phone_number"`
-	RoutingStatus              json.RawMessage `json:"routing_status"`
-	Visit                      json.RawMessage `json:"visit"`
-	Statistics                 json.RawMessage `json:"statistics"`
-	AgentLastEventCreatedAt    json.RawMessage `json:"agent_last_event_created_at"`
-	CustomerLastEventCreatedAt json.RawMessage `json:"customer_last_event_created_at"`
-	SessionFields              json.RawMessage `json:"session_fields"`
-	Followed                   json.RawMessage `json:"followed"`
-	Online                     json.RawMessage `json:"online"`
-	EmailVerified              json.RawMessage `json:"email_verified"`
-	State                      json.RawMessage `json:"state"`
-	GroupIDs                   json.RawMessage `json:"group_ids"`
-	GreetingID                 json.RawMessage `json:"greeting_id"`
-	CreatedAt                  json.RawMessage `json:"created_at"`
-	Visibility                 json.RawMessage `json:"visibility"`
-	Chats                      json.RawMessage `json:"chats"`
-	Tickets                    json.RawMessage `json:"tickets"`
-	Orders                     json.RawMessage `json:"orders"`
-	Omnichannel                json.RawMessage `json:"omnichannel"`
+	PhoneNumber                json.RawMessage `json:"phone_number,omitempty"`
+	RoutingStatus              json.RawMessage `json:"routing_status,omitempty"`
+	Visit                      json.RawMessage `json:"visit,omitempty"`
+	Statistics                 json.RawMessage `json:"statistics,omitempty"`
+	AgentLastEventCreatedAt    json.RawMessage `json:"agent_last_event_created_at,omitempty"`
+	CustomerLastEventCreatedAt json.RawMessage `json:"customer_last_event_created_at,omitempty"`
+	SessionFields              json.RawMessage `json:"session_fields,omitempty"`
+	Followed                   json.RawMessage `json:"followed,omitempty"`
+	Online                     json.RawMessage `json:"online,omitempty"`
+	EmailVerified              json.RawMessage `json:"email_verified,omitempty"`
+	State                      json.RawMessage `json:"state,omitempty"`
+	GroupIDs                   json.RawMessage `json:"group_ids,omitempty"`
+	GreetingID                 json.RawMessage `json:"greeting_id,omitempty"`
+	CreatedAt                  json.RawMessage `json:"created_at,omitempty"`
+	Visibility                 json.RawMessage `json:"visibility,omitempty"`
+	Chats                      json.RawMessage `json:"chats,omitempty"`
+	Tickets                    json.RawMessage `json:"tickets,omitempty"`
+	Orders                     json.RawMessage `json:"orders,omitempty"`
+	Omnichannel                json.RawMessage `json:"omnichannel,omitempty"`
 }
 
 // Agent function converts User object to Agent object if User's Type is "agent".


### PR DESCRIPTION
Context: I've updated lc-onboarding to API v3.6. After releasing to labs, I received the following errors:
```
"string": "failed to start chat: API responded with status code 422: error: validation - [`chat.users[0]`]: Map has too many keys, max count: 25, account email m.wojcik+20260513@livechat.com, event organizationID 7d3910f3-4b30-459e-93a6-4fd125282723, token organizationID 7d3910f3-4b30-459e-93a6-4fd125282723"
      },
```

Looks like the entire User struct has 26 fields, with adding the omitempty tags the requests should start getting through.