### PR TITLE
EUEE-1585: add customer phone_number to customer update_customer (v3.7)

### DIFF
--- a/customer/api.go
+++ b/customer/api.go
@@ -268,12 +268,13 @@ func (a *API) DeleteEvent(chatID, threadID, eventID string) error {
 }
 
 // UpdateCustomer updates current customer's info.
-func (a *API) UpdateCustomer(name, email, avatarURL *string, sessionFields []map[string]string, nameIsDefault *bool, address *AddressUpdate) error {
+func (a *API) UpdateCustomer(name, email, avatarURL, phoneNumber *string, sessionFields []map[string]string, nameIsDefault *bool, address *AddressUpdate) error {
 	return a.Call("update_customer", &updateCustomerRequest{
 		Name:          name,
 		NameIsDefault: nameIsDefault,
 		Email:         email,
 		Avatar:        avatarURL,
+		PhoneNumber:   phoneNumber,
 		SessionFields: sessionFields,
 		Address:       address,
 	}, &emptyResponse{})

--- a/customer/api_test.go
+++ b/customer/api_test.go
@@ -769,12 +769,13 @@ func TestUpdateCustomerShouldReturnDataReceivedFromCustomerAPI(t *testing.T) {
 	name := "stubName"
 	email := "stub@mail.com"
 	avatarURL := "http://stub.url"
+	phone := "+48123123123"
 	nameIsDefault := true
 	country := "United States"
 	address := &customer.AddressUpdate{
 		Country: &country,
 	}
-	rErr := api.UpdateCustomer(&name, &email, &avatarURL, []map[string]string{}, &nameIsDefault, address)
+	rErr := api.UpdateCustomer(&name, &email, &avatarURL, &phone, []map[string]string{}, &nameIsDefault, address)
 	if rErr != nil {
 		t.Errorf("UpdateCustomer failed: %v", rErr)
 	}
@@ -1235,11 +1236,12 @@ func TestUpdateCustomerShouldNotCrashOnErrorResponse(t *testing.T) {
 	name := "stubName"
 	email := "stub@mail.com"
 	avatarURL := "http://stub.url"
+	phone := "+48123123123"
 	country := "United States"
 	address := &customer.AddressUpdate{
 		Country: &country,
 	}
-	rErr := api.UpdateCustomer(&name, &email, &avatarURL, []map[string]string{}, nil, address)
+	rErr := api.UpdateCustomer(&name, &email, &avatarURL, &phone, []map[string]string{}, nil, address)
 	verifyErrorResponse("UpdateCustomer", rErr, t)
 }
 

--- a/customer/internal.go
+++ b/customer/internal.go
@@ -131,6 +131,7 @@ type updateCustomerRequest struct {
 	NameIsDefault *bool               `json:"name_is_default,omitempty"`
 	Email         *string             `json:"email,omitempty"`
 	Avatar        *string             `json:"avatar,omitempty"`
+	PhoneNumber   *string             `json:"phone_number,omitempty"`
 	SessionFields []map[string]string `json:"session_fields,omitempty"`
 	Address       *AddressUpdate      `json:"address,omitempty"`
 }

--- a/customer/structures.go
+++ b/customer/structures.go
@@ -73,6 +73,7 @@ type userSpecific struct {
 	SessionFields json.RawMessage `json:"session_fields,omitempty"`
 	Email         json.RawMessage `json:"email,omitempty"`
 	EmailVerified json.RawMessage `json:"email_verified,omitempty"`
+	PhoneNumber   json.RawMessage `json:"phone_number,omitempty"`
 	Address       json.RawMessage `json:"address,omitempty"`
 }
 
@@ -104,6 +105,9 @@ func (u *User) Customer() *Customer {
 		return nil
 	}
 	if err := json.Unmarshal(u.SessionFields, &c.SessionFields); err != nil {
+		return nil
+	}
+	if err := internal.UnmarshalOptionalRawField(u.PhoneNumber, &c.PhoneNumber); err != nil {
 		return nil
 	}
 	if err := internal.UnmarshalOptionalRawField(u.Address, &c.Address); err != nil {
@@ -214,6 +218,7 @@ type Customer struct {
 	*User
 	NameIsDefault bool                `json:"name_is_default"`
 	Email         string              `json:"email,omitempty"`
+	PhoneNumber   string              `json:"phone_number,omitempty"`
 	EmailVerified bool                `json:"email_verified,omitempty"`
 	SessionFields []map[string]string `json:"session_fields,omitempty"`
 	Address       *Address            `json:"address,omitempty"`


### PR DESCRIPTION
Add top-level phone_number to the customer SDK: UpdateCustomer accepts a phoneNumber arg, updateCustomerRequest carries it, and the Customer struct (incl. User.Customer() decode via userSpecific) exposes it. Mirrors the existing name/email handling and the agent SDK's customer phone support.